### PR TITLE
Disable composer memory limit when installing sample data

### DIFF
--- a/install-sampledata
+++ b/install-sampledata
@@ -2,7 +2,7 @@
 
 su www-data <<EOSU
 
-/var/www/html/bin/magento sampledata:deploy
+php -d memory_limit=-1 /var/www/html/bin/magento sampledata:deploy
 
 /var/www/html/bin/magento setup:upgrade
 


### PR DESCRIPTION
Fix composer fatal error due to memory limit :

Fatal error: Allowed memory size of 2147483648 bytes exhausted (tried to allocate 31457312 bytes) in /var/www/html/vendor/composer/composer/src/Composer/Util/RemoteFilesystem.php on line 594